### PR TITLE
Resolve non-determinism when verifying generated authentication token

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -37,7 +37,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +86,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(3, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(3, 1);
             headerMap.put("alg", "ES256");
             headerMap.put("typ", "JWT");
             headerMap.put("kid", this.keyId);
@@ -129,7 +129,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(2, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(2, 1);
             headerMap.put("iss", this.issuer);
             headerMap.put("iat", this.issuedAt.getEpochSecond());
 


### PR DESCRIPTION
### Description
In the validating tests of pushing notification handler that include token authentication, the `AuthenticationToken` constructor is called to set up the header. Within the constructor, the method `JsonSerializer.writeJsonTextAsString()` is used to parse the map representation of the key ID header into a Json String. This triggers `writeJsonText()` when parsing the input `HashMap` to a Json String. Currently, the parsing routine uses the default iterator of `HashMapmap.entrySet()`. The Oracle JDK specifies that the entry set of a normal `HashMap` returns a set view of all the mappings without guaranteed order. Therefore, the output authentication token may get scrambled if the code is compiled in a different JVM, or when Java upgrades in the future. In fact, the iteration order changed between Java 7 and 8, breaking a lot of unit tests.

### How we Discovered the Problem and Steps to Reproduce
The `NonDex` Maven plugin permutes `HashMap` iterators just as what happened between Java 7 and 8, and it reports test flakiness in a sample run. To reproduce, run `mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex` in the `pushy` submodule after a clean build.

### List of Unit Tests that may Fail in a Different JVM
```
TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithEmptyPayload
TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithCollapseId
TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithExpirationDate
TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithSpecifiedPriority
TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithMissingPayload
TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload
TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithValidNotification
TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken
```

### Sample Error Log (of `TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithEmptyPayload`)
The HashMap and HashSet default iteration order changed between Java 7 and 8, breaking lots of unit tests. Our NonDex plugin https://github.com/TestingResearchIllinois/NonDex permutes these orders just as between Java 7 and 8, and it produces the following output in a sample run: 
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.117 s <<< FAILURE! - in com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest
[ERROR] testHandleNotificationWithEmptyPayload  Time elapsed: 0.089 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: Push notifications with a device token for the wrong topic should be rejected. ==> expected: <PAYLOAD_EMPTY> but was: <INVALID_PROVIDER_TOKEN>
```

### Suggested Fix
Use `LinkedHashMap` instead when converting key ID to `Map` instead. This ensures deterministic order in Json parsing, such that the output authentication token retains input order. Note that `LinkedHashMap` iterators are also faster.
